### PR TITLE
WIP Fix test_saved_search.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ flatpak/bundles
 
 # src/ usually has development version of liblarch
 src/
+
+# Python virtual environments
+venv*/

--- a/GTG/core/base_store.py
+++ b/GTG/core/base_store.py
@@ -25,7 +25,7 @@ from uuid import UUID
 import logging
 
 from lxml.etree import Element
-from typing import List, Any, Dict
+from typing import Any, Dict, List, Optional
 
 
 log = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ class BaseStore(GObject.Object):
         return self.lookup[key]
 
 
-    def add(self, item: Any, parent_id: UUID = None) -> None:
+    def add(self, item: Any, parent_id: Optional[UUID] = None) -> None:
         """Add an existing item to the store."""
 
         if item.id in self.lookup.keys():
@@ -105,7 +105,7 @@ class BaseStore(GObject.Object):
         """Remove an existing item from the store."""
 
         item = self.lookup[item_id]
-        
+
         try:
             parent = item.parent
 

--- a/GTG/core/saved_searches.py
+++ b/GTG/core/saved_searches.py
@@ -44,7 +44,12 @@ class SavedSearch(GObject.Object):
         self._query = query
         self._icon = None
 
-        super(SavedSearch, self).__init__()
+        super().__init__()
+
+    # TODO probably not needed
+    @classmethod
+    def create(cls, name: str, query: str) -> 'SavedSearch':
+        return cls(uuid4(), name, query)
 
     @GObject.Property(type=str)
     def name(self) -> str:
@@ -160,23 +165,10 @@ class SavedSearchStore(BaseStore):
         return root
 
 
-    def new(self, name: str, query: str, parent: UUID = None) -> SavedSearch:
-        """Create a new saved search and add it to the store."""
+    def add(self, search: SavedSearch) -> None:
+        """Add a search to the store."""
 
-        search_id = uuid4()
-        search = SavedSearch(id=search_id, name=name, query=query)
-
-        self.data.append(search)
-        self.lookup[search_id] = search
+        super().add(search, None)
         self.model.append(search)
 
-        return search
-    
-
-    def add(self, item, parent_id: UUID = None) -> None:
-        """Add a tag to the tagstore."""
-
-        super().add(item, parent_id)
-        self.model.append(item)
-
-        self.emit('added', item)
+        self.emit('added', search)

--- a/tests/core/test_saved_search.py
+++ b/tests/core/test_saved_search.py
@@ -20,23 +20,10 @@ from unittest import TestCase
 from uuid import uuid4
 
 from GTG.core.saved_searches import SavedSearch, SavedSearchStore
-from lxml.etree import Element, XML
+from lxml.etree import XML
 
 
 class TestSavedSearch(TestCase):
-
-    def test_new_simple(self):
-        store = SavedSearchStore()
-        search = store.new('Some @tag', 'Looking for some tag')
-
-        # Make sure we have added a new search
-        self.assertEqual(len(store.data), 1)
-
-        # Make sure it's the same one we received
-        self.assertEqual(store.lookup[search.id], search)
-
-        # Make sure it's an instance of SavedSearch
-        self.assertIsInstance(search, SavedSearch)
 
 
     def test_add_simple(self):
@@ -45,7 +32,7 @@ class TestSavedSearch(TestCase):
         store = SavedSearchStore()
 
         self.assertEqual(len(store.data), 0)
-        result = store.add(search)
+        store.add(search)
 
         self.assertEqual(len(store.data), 1)
 
@@ -58,77 +45,15 @@ class TestSavedSearch(TestCase):
 
     def test_remove_simple(self):
         store = SavedSearchStore()
-        search = store.new('Some @tag', 'Looking for some tag')
+        search = SavedSearch(uuid4(), 'Some @tag', 'Looking for some tag')
+        store.add(search)
 
         self.assertEqual(len(store.data), 1)
         store.remove(search.id)
         self.assertEqual(len(store.data), 0)
 
         with self.assertRaises(KeyError):
-            store.remove('000')
-
-
-    def test_new_tree(self):
-
-        store = SavedSearchStore()
-
-        root_1 = store.new('Root search', '@tag')
-        root_2 = store.new('Root search 2', '@tag2')
-
-        child_1 = store.new('Child search 1', '@another_tag', root_1.id)
-        child_2 = store.new('Child search 2', '@another_tag', root_2.id)
-
-        child_3 = store.new('Child search 3', '@another_tag', child_2.id)
-
-        self.assertEqual(len(store.lookup), 5)
-        self.assertEqual(len(store.data), 2)
-        self.assertEqual(len(root_1.children), 1)
-        self.assertEqual(len(child_2.children), 1)
-
-        with self.assertRaises(KeyError):
-            store.new('An error', '@error', '000')
-
-
-    def test_add_tree(self):
-
-        store = SavedSearchStore()
-
-        search_1 = SavedSearch(id=uuid4(), name='Test 1', query='@tag1')
-        search_2 = SavedSearch(id=uuid4(), name='Test 2', query='@tag2')
-        search_3 = SavedSearch(id=uuid4(), name='Test 3', query='@tag3')
-        search_4 = SavedSearch(id=uuid4(), name='Test 4', query='@tag4')
-        search_5 = SavedSearch(id=uuid4(), name='Test 5', query='@tag5')
-
-
-        store.add(search_1)
-        store.add(search_2)
-        store.add(search_3, search_1.id)
-        store.add(search_4, search_3.id)
-        store.add(search_5, search_3.id)
-
-
-    def test_remove_tree(self):
-        store = SavedSearchStore()
-
-        root_1 = store.new('Root search', '@tag')
-        root_2 = store.new('Root search 2', '@tag2')
-
-        child_1 = store.new('Child search 1', '@another_tag', root_1.id)
-        child_2 = store.new('Child search 2', '@another_tag', root_2.id)
-
-        child_3 = store.new('Child search 3', '@another_tag', child_2.id)
-
-        self.assertEqual(len(store.lookup), 5)
-        store.remove(child_3.id)
-
-        self.assertEqual(len(store.lookup), 4)
-        self.assertEqual(len(child_2.children), 0)
-
-        store.remove(root_1.id)
-        store.remove(root_2.id)
-
-        self.assertEqual(len(store.lookup), 0)
-        self.assertEqual(len(store.data), 0)
+            store.remove(uuid4())
 
 
     def test_count(self):


### PR DESCRIPTION
Building on top of #1036

The goal is to get a green run of `./run-tests tests/core/test_saved_search.py`.

The main problem is that some tests assume that searches are saved as a tree (same as tasks and tags), but they are not. So I'm essentially removing these tree tests, along with `SavedSearchStore.new()`, whose job was to "Create a new saved search and add it to the store.". The problem with that is that there is already a way to add something to the store and it's called `add()`. Once you remove that duplication, `SavedSearchStore.new()` is just a way to create a `SavedSearch`, which belongs in the `SavedSearch` class instead.